### PR TITLE
fix: brute force check for up-to-date classdata.tpk within MelonLoader.dll

### DIFF
--- a/AudioCore.cs
+++ b/AudioCore.cs
@@ -1,6 +1,7 @@
 ﻿using AssetsTools.NET.Extra;
 using AssetsTools.NET;
 using MelonLoader;
+using System.Reflection;
 
 namespace AudioCore
 {
@@ -27,7 +28,13 @@ namespace AudioCore
             {
                 AssetsManager am = new AssetsManager();
                 AssetsFileInstance afi = am.LoadAssetsFile(Path.Combine(DataPath, AssetFile), false);
-                MelonUtils.LoadIncludedClassPackage(am);
+
+                if (!TryLoadIncludedClassPackage(am))
+                {
+                    MelonLogger.Msg("Could not load MelonLoader's classdata.tpk -- a tpk update may be required. Aborting.");
+                    return;
+                }
+
                 am.LoadClassDatabaseFromPackage(afi.file.Metadata.UnityVersion);
 
                 AssetFileInfo audioInfo = afi.file.GetAssetsOfType(AssetClassID.AudioManager)[0];
@@ -45,15 +52,12 @@ namespace AudioCore
                 {
                     audioBaseField.Get("m_DisableAudio").Value.AsBool = !enableAudio;
 
-                    List<AssetsReplacer> reps = new List<AssetsReplacer>
-                    {
-                    new AssetsReplacerFromMemory(afi.file, audioInfo, audioBaseField)
-                    };
+                    audioInfo.SetNewData(audioBaseField);
 
                     using (MemoryStream memStream = new MemoryStream())
                     using (AssetsFileWriter writer = new AssetsFileWriter(memStream))
                     {
-                        afi.file.Write(writer, 0, reps);
+                        afi.file.Write(writer, 0);
                         am.UnloadAllAssetsFiles();
                         File.WriteAllBytes(Path.Combine(DataPath, AssetFile), memStream.ToArray());
                     }
@@ -73,6 +77,27 @@ namespace AudioCore
             {
                 MelonLogger.Msg($"An exception was encountered while attempting to toggle Unity audio: {ex.Message}");
             }
+        }
+
+        private static bool TryLoadIncludedClassPackage(AssetsManager am)
+        {
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                string[] names;
+                try { names = asm.GetManifestResourceNames(); }
+                catch { continue; }
+
+                string name = names.FirstOrDefault(n => n.EndsWith("classdata.tpk", StringComparison.OrdinalIgnoreCase));
+                if (name == null) continue;
+
+                using Stream s = asm.GetManifestResourceStream(name);
+                MemoryStream ms = new MemoryStream();
+                s.CopyTo(ms);
+                ms.Position = 0;
+                am.LoadClassPackage(ms);
+                return true;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
Looks like the classpak.tpk within MelonLoader covers up to ~6000.4ish from a december, so until HL pulls another gigantic update this should work.

Fingers crossed ML never un-embeds it or we will have to try something different like you mentioned, UABEA etc